### PR TITLE
Make request.pg available in auth code.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var pg = require('pg');
 
 exports.register = function (server, options, next) {
 
-    server.ext('onPreHandler', function (request, reply) {
+    server.ext('onPreAuth', function (request, reply) {
 
         pg.connect(options.connectionString, function (err, client, done) {
 


### PR DESCRIPTION
Make the `request.pg` object available, so it can also be used for authentication.
